### PR TITLE
remove obsolete label element in metadata-schema.component.html

### DIFF
--- a/src/app/admin/admin-registries/metadata-schema/metadata-schema.component.html
+++ b/src/app/admin/admin-registries/metadata-schema/metadata-schema.component.html
@@ -41,7 +41,7 @@
                   </label>
                 </td>
                 <td class="selectable-row" (click)="editField(field)">{{field.id}}</td>
-                <td class="selectable-row" (click)="editField(field)">{{schema?.prefix}}.{{field.element}}<label *ngIf="field.qualifier" class="mb-0">.</label>{{field.qualifier}}</td>
+                <td class="selectable-row" (click)="editField(field)">{{schema?.prefix}}.{{field.element}}{{field.qualifier ? '.' + field.qualifier : ''}}</td>                
                 <td class="selectable-row" (click)="editField(field)">{{field.scopeNote}}</td>
               </tr>
               </tbody>


### PR DESCRIPTION
## Description

This PR implements a minor HTML change which improves the "find in page" of your prefered web browser. Currently, it is not possible to search for metadata field names of the form `schema.element.qualifier` with the "find in page" function, e.g. in `/admin/registries/metadata/dc`.

